### PR TITLE
Fix undefined variable

### DIFF
--- a/classes/websiteinfo.php
+++ b/classes/websiteinfo.php
@@ -20,7 +20,7 @@ class WebsiteInfo extends Basic {
 	
 	public function select($intIDNum, $numericIDOnly=true) {
 		$temp = $this->arrObjInfo;
-		$returnVal = parent::select($intIDNum, $numerIDOnly);
+		$returnVal = parent::select($intIDNum, $numericIDOnly);
 		
 		
 		if($this->blnRefreshInfo) {


### PR DESCRIPTION
Typo in $numericIdOnly , line 23 was causing PHP undefined var warning.
