### PR TITLE
Preserve News Comment Line Breaks

### DIFF
--- a/_functions.php
+++ b/_functions.php
@@ -14,7 +14,11 @@
 
 
 
-include($prevFolder."include/lib_autolink/lib_autolink.php");
+if(isset($prevFolder)){
+        include($prevFolder."include/lib_autolink/lib_autolink.php");
+}else{
+        include("include/lib_autolink/lib_autolink.php");
+}
 
 
 // General functions to filter out all <, >, ", and ' symbols

--- a/_setup.php
+++ b/_setup.php
@@ -40,7 +40,12 @@ if(!isset($_SESSION['csrfKey'])) {
 	$_SESSION['csrfKey'] = md5(uniqid());
 }
 
-include($prevFolder."_config.php");
+if(isset($prevFolder)){
+        include($prevFolder."_config.php");
+} else {
+        include("_config.php");
+}
+
 define("BASE_DIRECTORY", $BASE_DIRECTORY);
 //define("BASE_DIRECTORY", str_replace("//", "/", $_SERVER['DOCUMENT_ROOT'].$MAIN_ROOT));
 define("MAIN_ROOT", $MAIN_ROOT);

--- a/news/comments.php
+++ b/news/comments.php
@@ -43,7 +43,7 @@ foreach($arrComments as $commentID) {
 		
 		
 		<p class='main' style='margin-bottom: 40px'>
-		".$commentInfo['message']."<br>
+		".nl2br($commentInfo['message'])."<br>
 		".$member->getMemberLink()." &nbsp; ".getPreciseTime($commentInfo['dateposted']).$dispDelete."
 		</p>
 		


### PR DESCRIPTION
I made this change to my local copy to preserve line breaks in news comments that the commenter intended.

I apologize if this is done incorrectly.  I've never done any contributing to projects ever before.
